### PR TITLE
Feat/check executable

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,4 @@ parameters:
     excludePaths:
         - tests/Fixtures/app/guides/*
         - tests/Command/src/*
+        - tests/Command/guides/*

--- a/src/Command/GuideCommand.php
+++ b/src/Command/GuideCommand.php
@@ -28,7 +28,7 @@ final class GuideCommand extends Command
     use CommandTrait;
 
     // Regular expression to match comment
-    private const REGEX = '/^\s*\/\/\s/';
+    public const REGEX = '/^\s*\/\/\s/';
 
     public function __construct(
         private readonly ConfigurationHandler $configuration,

--- a/src/Playground/PlaygroundTestCase.php
+++ b/src/Playground/PlaygroundTestCase.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace PhpDocumentGenerator\Playground;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
-use LogicException;
 
 use function App\Playground\request; // @phpstan-ignore-line
 
@@ -24,16 +23,9 @@ class PlaygroundTestCase extends ApiTestCase
 
     public function testGuideRequest(): void
     {
-        if (!\function_exists('App\Playground\request')) {
-            $this->markTestSkipped('No function request defined');
-        }
-
         $kernel = static::createKernel();
-        if (!\function_exists('App\Playground\request')) {
-            throw new LogicException('Unable to perform a request. Did you forget to setup the request?');
-        }
 
-        $request = request();
+        $request = request(); // @phpstan-ignore-line
         $response = $kernel->handle($request);
         $kernel->terminate($request, $response);
         $this->assertLessThan(500, $response->getStatusCode());


### PR DESCRIPTION
Adds a check to see if a guide is said to be executable (for the Playground) in FrontMatter but defines no `App\Playground\request` function